### PR TITLE
chore: rename IQAICOM/IQAIcom to IQOfficial

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npx @iqai/mcp-near-intent-swaps
 ### 🔧 Build from Source
 
 ```bash
-git clone https://github.com/IQAIcom/mcp-near-intent-swaps.git
+git clone https://github.com/IQOfficial/mcp-near-intent-swaps.git
 cd mcp-near-intent-swaps
 pnpm install
 pnpm run build


### PR DESCRIPTION
Renames `IQAICOM`, `IQAIcom`, and `iqaicom` references to `IQOfficial` / `iqofficial` (case-preserving) as part of the brand handle rename. Covers Twitter/X handles, GitHub URLs, Telegram links, package metadata, badges, and docs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>